### PR TITLE
allow year of birth only when calculating age.

### DIFF
--- a/R/query_functions.R
+++ b/R/query_functions.R
@@ -53,7 +53,9 @@ omop_connect <-
 #' Should match the example_concepts.tsv file format.
 #' @param severity_score
 #' The name of the severity score to calculate. Only APACHE II at the moment.
-#'
+#' @param age_method
+#' Either 'year_only' or 'dob'. Decides if age is calculated from year of birth or full DOB
+#' Default is 'dob'
 #' @import lubridate
 #' @import DBI
 #' @import dplyr
@@ -64,7 +66,8 @@ get_score_variables <- function(conn, dialect, schema,
                                 start_date, end_date,
                                 min_day, max_day,
                                 concepts_file_path,
-                                severity_score) {
+                                severity_score,
+                                age_method = "dob") {
   # Editing the date variables to keep explicit single quote for SQL
   start_date <- single_quote(start_date)
   end_date <- single_quote(end_date)
@@ -75,10 +78,27 @@ get_score_variables <- function(conn, dialect, schema,
     filter(score == severity_score)
 
   # First getting admission information
+  # Age query
+  if (!(age_method %in% c("dob", "year_only"))) {
+  stop("Error: age_method must be either 'dob' or 'year_only'")
+}
+  age_query <- ifelse(
+    age_method == "dob",
+  " DATEDIFF(yyyy,
+			  COALESCE(p.birth_datetime, DATEFROMPARTS(p.year_of_birth, COALESCE(p.month_of_birth, '06'),
+          COALESCE(p.day_of_birth, '01'))),
+			  COALESCE(vd.visit_detail_start_datetime, vd.visit_detail_start_date,
+        vo.visit_start_datetime, vo.visit_start_date)) as age",
+  " YEAR(COALESCE(vd.visit_detail_start_datetime, vd.visit_detail_start_date,
+                   vo.visit_start_datetime, vo.visit_start_date)) - p.year_of_birth AS age") %>%
+  SqlRender::translate(tolower(dialect))
+
+  # Admission information
   raw_sql <- readr::read_file(
     system.file("admission_details.sql", package = "SeverityScoresOMOP")) %>%
     SqlRender::translate(tolower(dialect)) %>%
     SqlRender::render(schema             = schema,
+                      age_query          = age_query,
                       start_date         = start_date,
                       end_date           = end_date)
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@
     ### The min and max date arguments describe how many days after ICU admisison to get data for.
     ### Setting min to 0 and max to 1 gives the first 24 hours of ICU admission.
     ### Each day of data per visit is a separate row in the output dataset. 
+    ### Age method is used to calculate age. It decides whether to use date of birth, or just year of birth. Options are 'dob' (default) or 'year_only'
     data <- get_score_variables(omop_conn, "your_sql_dialect", "your_schema_name", 
                                 start_date = "2022-07-01", end_date = "2022-07-31",
                                 min_day = 0, max_day = 1, 
                                 concepts_file_path = "path_to_your_concepts_file", 
-                                severity_score = "APACHE II")
+                                severity_score = "APACHE II", age_method = 'dob')
     dbDisconnect(omop_conn)
     
     ### Standardise units of measure and calculate the APACHE II score.

--- a/inst/admission_details.sql
+++ b/inst/admission_details.sql
@@ -4,14 +4,12 @@ SELECT p.person_id
 	--- Some databases don't have month/day of birth. Others don't have birth datetime.
 	--- Imputing DOB as the middle of the year if no further information is available.
 	--- Also, not all databases have datetimes, so we have to impute the date as midnight.
-	,DATEDIFF(yyyy,
-			  COALESCE(p.birth_datetime, DATEFROMPARTS(p.year_of_birth, COALESCE(p.month_of_birth, '06'), COALESCE(p.day_of_birth, '01'))),
-			  COALESCE(vd.visit_detail_start_datetime, vd.visit_detail_start_date, vo.visit_start_datetime, vo.visit_start_date)
-			  ) as age
+	, @age_query
 	,c_gender.concept_name AS gender
 	,vo.visit_occurrence_id
 	,vd.visit_detail_id
-	,COALESCE(vd.visit_detail_start_datetime, vd.visit_detail_start_date, vo.visit_start_datetime, vo.visit_start_date) AS icu_admission_datetime
+	,COALESCE(vd.visit_detail_start_datetime, vd.visit_detail_start_date,
+	vo.visit_start_datetime, vo.visit_start_date) AS icu_admission_datetime
 FROM @schema.person p
 INNER JOIN @schema.visit_occurrence vo ON p.person_id = vo.person_id
 -- this should contain ICU stay information, if it exists at all

--- a/man/get_score_variables.Rd
+++ b/man/get_score_variables.Rd
@@ -15,7 +15,8 @@ get_score_variables(
   min_day,
   max_day,
   concepts_file_path,
-  severity_score
+  severity_score,
+  age_method = "dob"
 )
 }
 \arguments{
@@ -34,6 +35,9 @@ get_score_variables(
 \item{max_day}{Days since ICU admission to get physiology data for.}
 
 \item{severity_score}{The name of the severity score to calculate. Only APACHE II at the moment.}
+
+\item{age_method}{Either 'year_only' or 'dob'. Decides if age is calculated from year of birth or full DOB
+Default is 'dob'}
 
 \item{mapping_path}{Path to the custom *_concepts.tsv file containing score to OMOP mappings.
 Should match the example_concepts.tsv file format.}


### PR DESCRIPTION
Hi @DanielPuttmann. 
I realised that since CCAA only collects age (not date of birth), the age calculation which imputes date of birth in the middle of the year is sometimes wrong by 1 year.

Since imputing as the middle of the year is the OMOP recommendation, I've added 2 versions of the query to allow the user to choose. Will you have a look?