### PR TITLE
Fixed abiguous ids in dynamic sql

### DIFF
--- a/R/query_functions.R
+++ b/R/query_functions.R
@@ -252,7 +252,7 @@ get_score_variables <- function(conn, dialect, schema,
         omop_variable == "value_as_concept_id" ~
         glue(
         ", COUNT ( CASE WHEN o.observation_concept_id = {concept_id}
-                        AND value_as_concept_id
+                        AND o.value_as_concept_id
                         IN ({concept_id_value})
                         THEN o.observation_id
                     END ) AS count_{short_name}"


### PR DESCRIPTION
I installed the SeverityScoresOMOP from github to run the code with all changes you made, but some of mine got lost in the process. I got an ambiguity error from an sql file. Turns out it was in the dynamic code in R. I fixed it, the code runs for me now.
Could you take a look at it?